### PR TITLE
Update jquery.jtable.toolbarsearch.js

### DIFF
--- a/lib/extensions/jquery.jtable.toolbarsearch.js
+++ b/lib/extensions/jquery.jtable.toolbarsearch.js
@@ -98,6 +98,11 @@
                 .css('width', field.width)
                 .data('fieldName', fieldName)
                 .append($headerContainerDiv);
+		
+	    //hide the table header if the corresponding field is hidden	
+	    if(field.visibility==='hidden'){
+		$th.hide();
+	    }	
 
             return $th;
         }


### PR DESCRIPTION
Currently if there are hidden columns the plugin will still render the search field messing up column alignment, this small change fixes it: it hides the additional table header if the corresponding field is hidden.